### PR TITLE
Allow ca-fingerprint certificate to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ The primary use of this toolkit is self-issuing `X509Credential`s through a `did
 To issue an `X509Credential`, provide the following parameters:
 
 - **certificate_file**: the PEM file of the certificate
+- **ca_fingerprint_dn**: the DN of the certificate in the chain that should be used as ca-fingerprint. 
+  It must be one of the intermediate CA or root CAs. If invalid, it prints the DNs of the certificates in the chain.
 - **signing_key**: the unencrypted PEM file of the private key used for signing.
 - **credential_subject**: the ID of the credential subject, typically a DID.
 
 Usage:
 ```shell
-./issuer vc <certificate_file> <signing_key> <credential_subject>
+./issuer vc <certificate_file> <signing_key> <ca_fingerprint_dn> <credential_subject>
 ```
 
 Example:
 ```shell
-./issuer vc certificate.pem key.pem did:web:example.com
+./issuer vc certificate.pem key.pem "CN=Fake Root CA"  did:web:example.com
 ```
 
 ### Validating `X509Credential`s

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ To issue an `X509Credential`, provide the following parameters:
 - **certificate_file**: the PEM file of the certificate
 - **ca_fingerprint_dn**: the DN of the certificate in the chain that should be used as ca-fingerprint. 
   It must be one of the intermediate CA or root CAs. If invalid, it prints the DNs of the certificates in the chain.
-- **signing_key**: the unencrypted PEM file of the private key used for signing.
+- **signing_key_file**: the unencrypted PEM file of the private key used for signing.
 - **credential_subject**: the ID of the credential subject, typically a DID.
 
 Usage:
 ```shell
-./issuer vc <certificate_file> <signing_key> <ca_fingerprint_dn> <credential_subject>
+./issuer vc <certificate_file> <signing_key_file> <ca_fingerprint_dn> <credential_subject>
 ```
 
 Example:

--- a/credential_issuer/issuer_test.go
+++ b/credential_issuer/issuer_test.go
@@ -64,13 +64,11 @@ func TestBuildX509Credential(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			certificates, signingKey, subject := tt.in(t)
-			_, err := Issue(certificates, signingKey, subject)
-			if err != nil {
-				if err.Error() != tt.errorText {
-					t.Errorf("TestBuildX509Credential() error = '%v', wantErr '%v'", err.Error(), tt.errorText)
-				}
-			} else if err == nil && tt.errorText != "" {
-				t.Errorf("TestBuildX509Credential() unexpected success, want error")
+			_, err := Issue(certificates, certificates[2], signingKey, subject)
+			if tt.errorText == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.errorText)
 			}
 		})
 	}
@@ -83,7 +81,7 @@ func TestIssue(t *testing.T) {
 		validChain, err := internal.ParseCertificatesFromPEM([]byte(internal.TestCertificateChain))
 		require.NoError(t, err, "failed to parse chain")
 
-		vc, err := Issue(validChain, validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization, x509_cert.SubjectTypeLocality))
+		vc, err := Issue(validChain, validChain[3], validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization, x509_cert.SubjectTypeLocality))
 
 		require.NoError(t, err, "failed to issue verifiable credential")
 		require.NotNil(t, vc, "verifiable credential is nil")
@@ -116,7 +114,7 @@ func TestIssue(t *testing.T) {
 
 		validChain[0].Subject.Organization = []string{"FauxCare & Co"}
 
-		vc, err := Issue(validChain, validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization))
+		vc, err := Issue(validChain, validChain[3], validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization))
 
 		assert.Equal(t, "did:x509:0:sha256:DwXSf2_jaUod7cezXBGJBM4AaaoA8DI9j7aPMDTI-mQ::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:O:FauxCare%20%26%20Co", vc.Issuer.String())
 	})

--- a/main.go
+++ b/main.go
@@ -13,12 +13,12 @@ import (
 )
 
 type VC struct {
-	CertificateFile string `arg:"" name:"certificate_file" help:"Certificate PEM file. If the file contains a chain, the chain will be used for signing." type:"existingfile"`
-	SigningKey      string `arg:"" name:"signing_key" help:"PEM key for signing." type:"existingfile"`
+	CertificateFile string `arg:"" name:"certificate_file" help:"PEM file containing the full certificate chain." type:"existingfile"`
+	SigningKeyFile  string `arg:"" name:"signing_key_file" help:"PEM file containing the private key of the leaf certificate." type:"existingfile"`
 	// CAFingerprintDN specifies the subject DN of the certificate that should be used as did:x509 ca-fingerprint property.
-	CAFingerprintDN   string                      `arg:"" short:"c" name:"ca_fingerprint_dn" help:"The subject DN of the CA certificate that should be used as did:x509 ca-fingerprint property."`
-	SubjectDID        string                      `arg:"" name:"subject_did" help:"The subject DID of the VC."`
-	SubjectAttributes []x509_cert.SubjectTypeName `short:"s" name:"subject_attr" help:"A list of Subject Attributes u in the VC." default:"O,L"`
+	CAFingerprintDN   string                      `arg:"" short:"c" name:"ca_fingerprint_dn" help:"The full subject DN (distinguished name) of the CA certificate to be used as ca-fingerprint in the X.509 DID. The certificate must be present in the chain specified by certificate_file."`
+	SubjectDID        string                      `arg:"" name:"subject_did" help:"The subject DID of the Verifiable Credential."`
+	SubjectAttributes []x509_cert.SubjectTypeName `short:"s" name:"subject_attr" help:"List of X.509 subject attributes to include in the Verifiable Credential." default:"O,L"`
 	IncludePermanent  bool                        `short:"p" help:"Include the permanent identifier in the did:x509."`
 }
 
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	switch ctx.Command() {
-	case "vc <certificate_file> <signing_key> <ca_fingerprint_dn> <subject_did>":
+	case "vc <certificate_file> <signing_key_file> <ca_fingerprint_dn> <subject_did>":
 		vc := cli.Vc
 		jwt, err := issueVc(vc)
 		if err != nil {
@@ -115,7 +115,7 @@ func issueVc(vc VC) (string, error) {
 		return "", InvalidCAFingerprintDNError{Candidates: candidates}
 	}
 
-	keyFileData, err := os.ReadFile(vc.SigningKey)
+	keyFileData, err := os.ReadFile(vc.SigningKeyFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to read key file: %w", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/nuts-foundation/go-didx509-toolkit/issues/31

When invalid, it prints the DNs of the certificates in the chain, helping the user to specify the right one.