### PR TITLE
permanentIdentifier: only include if explicitly specified

### DIFF
--- a/credential_issuer/issuer.go
+++ b/credential_issuer/issuer.go
@@ -28,22 +28,22 @@ var CredentialType = ssi.MustParseURI("X509Credential")
 
 // issueOptions contains values for options for issuing a UZI VC.
 type issueOptions struct {
-	includePermanentIdentifier bool
-	subjectAttributes          []x509_cert.SubjectTypeName
+	subjectAttributes []x509_cert.SubjectTypeName
+	sanAttributes     []x509_cert.SanTypeName
 }
 
 // Option is an interface for a function in the options pattern.
 type Option = func(*issueOptions)
 
 var defaultIssueOptions = &issueOptions{
-	includePermanentIdentifier: false,
-	subjectAttributes:          []x509_cert.SubjectTypeName{},
+	sanAttributes:     []x509_cert.SanTypeName{x509_cert.SanTypeOtherName},
+	subjectAttributes: []x509_cert.SubjectTypeName{},
 }
 
 func Issue(chain []*x509.Certificate, caFingerprintCert *x509.Certificate, key *rsa.PrivateKey, subject string, optionFns ...Option) (*vc.VerifiableCredential, error) {
-	options := defaultIssueOptions
+	options := *defaultIssueOptions
 	for _, fn := range optionFns {
-		fn(options)
+		fn(&options)
 	}
 
 	// Sanity check: make sure caFingerprintCert is in the chain
@@ -58,27 +58,22 @@ func Issue(chain []*x509.Certificate, caFingerprintCert *x509.Certificate, key *
 		return nil, errors.New("caFingerprintCert is not in the chain")
 	}
 
-	types := []x509_cert.SanTypeName{x509_cert.SanTypeOtherName}
-	if options.includePermanentIdentifier {
-		types = append(types, x509_cert.SanTypePermanentIdentifierValue)
-		types = append(types, x509_cert.SanTypePermanentIdentifierAssigner)
-	}
-
-	issuer, err := did_x509.CreateDid(chain[0], caFingerprintCert, options.subjectAttributes, types...)
+	issuer, err := did_x509.CreateDid(chain[0], caFingerprintCert, options.subjectAttributes, options.sanAttributes...)
 	if err != nil {
 		return nil, err
 	}
 	// signing cert is at the start of the chain
 	signingCert := chain[0]
-	otherNameValues, err := x509_cert.FindSanTypes(signingCert)
+	sanValues, err := x509_cert.SelectSanTypes(signingCert, options.sanAttributes...)
 	if err != nil {
 		return nil, err
 	}
+
 	subjectTypes, err := x509_cert.SelectSubjectTypes(signingCert, options.subjectAttributes...)
 	if err != nil {
 		return nil, err
 	}
-	template, err := buildCredential(*issuer, signingCert.NotAfter, otherNameValues, subjectTypes, subject)
+	template, err := buildCredential(*issuer, signingCert.NotAfter, sanValues, subjectTypes, subject)
 	if err != nil {
 		return nil, err
 	}
@@ -121,10 +116,17 @@ func Issue(chain []*x509.Certificate, caFingerprintCert *x509.Certificate, key *
 	})
 }
 
-// SubjectAttributes sets the subject attributes to include in the UZI VC.
+// SubjectAttributes sets the subject attributes to include in the DID and VC.
 func SubjectAttributes(attributes ...x509_cert.SubjectTypeName) Option {
 	return func(o *issueOptions) {
 		o.subjectAttributes = attributes
+	}
+}
+
+// SANAttributes sets whether to include the SAN permanent identifier in the DID and VC.
+func SANAttributes(attributes ...x509_cert.SanTypeName) Option {
+	return func(o *issueOptions) {
+		o.sanAttributes = attributes
 	}
 }
 

--- a/credential_issuer/issuer_test.go
+++ b/credential_issuer/issuer_test.go
@@ -4,10 +4,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-didx509-toolkit/internal"
 	"testing"
 
-	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-didx509-toolkit/x509_cert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,34 +78,63 @@ func TestIssue(t *testing.T) {
 	validKey, err := internal.ParseRSAPrivateKeyFromPEM([]byte(internal.TestSigningKey))
 	require.NoError(t, err, "failed to parse signing key")
 	t.Run("ok - happy path", func(t *testing.T) {
-		validChain, err := internal.ParseCertificatesFromPEM([]byte(internal.TestCertificateChain))
-		require.NoError(t, err, "failed to parse chain")
+		t.Run("include all", func(t *testing.T) {
+			validChain, err := internal.ParseCertificatesFromPEM([]byte(internal.TestCertificateChain))
+			require.NoError(t, err, "failed to parse chain")
 
-		vc, err := Issue(validChain, validChain[3], validKey, "did:example:123", SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization, x509_cert.SubjectTypeLocality))
+			vc, err := Issue(validChain, validChain[3], validKey, "did:example:123",
+				SubjectAttributes(x509_cert.SubjectTypeCountry, x509_cert.SubjectTypeOrganization, x509_cert.SubjectTypeLocality),
+				SANAttributes(x509_cert.SanTypeOtherName, x509_cert.SanTypePermanentIdentifierAssigner, x509_cert.SanTypePermanentIdentifierValue),
+			)
 
-		require.NoError(t, err, "failed to issue verifiable credential")
-		require.NotNil(t, vc, "verifiable credential is nil")
+			require.NoError(t, err, "failed to issue verifiable credential")
+			require.NotNil(t, vc, "verifiable credential is nil")
 
-		assert.Equal(t, "https://www.w3.org/2018/credentials/v1", vc.Context[0].String())
-		assert.True(t, vc.IsType(ssi.MustParseURI("VerifiableCredential")))
-		assert.True(t, vc.IsType(ssi.MustParseURI("X509Credential")))
-		assert.Equal(t, "did:x509:0:sha256:DwXSf2_jaUod7cezXBGJBM4AaaoA8DI9j7aPMDTI-mQ::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333::subject:L:Testland:O:Faux%20Care", vc.Issuer.String())
+			assert.Equal(t, "https://www.w3.org/2018/credentials/v1", vc.Context[0].String())
+			assert.True(t, vc.IsType(ssi.MustParseURI("VerifiableCredential")))
+			assert.True(t, vc.IsType(ssi.MustParseURI("X509Credential")))
+			assert.Equal(t, "did:x509:0:sha256:DwXSf2_jaUod7cezXBGJBM4AaaoA8DI9j7aPMDTI-mQ::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333:permanentIdentifier.assigner:2.16.528.1.1007.3.3:permanentIdentifier.value:2222222::subject:L:Testland:O:Faux%20Care", vc.Issuer.String())
 
-		expectedCredentialSubject := []interface{}{map[string]interface{}{
-			"id": "did:example:123",
-			"subject": map[string]interface{}{
-				"O": "Faux Care",
-				"L": "Testland",
-			},
-			"san": map[string]interface{}{
-				"otherName":                    "2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333",
-				"permanentIdentifier.assigner": "2.16.528.1.1007.3.3",
-				"permanentIdentifier.value":    "2222222",
-			},
-		}}
+			expectedCredentialSubject := []interface{}{map[string]interface{}{
+				"id": "did:example:123",
+				"subject": map[string]interface{}{
+					"O": "Faux Care",
+					"L": "Testland",
+				},
+				"san": map[string]interface{}{
+					"otherName":                    "2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333",
+					"permanentIdentifier.assigner": "2.16.528.1.1007.3.3",
+					"permanentIdentifier.value":    "2222222",
+				},
+			}}
 
-		assert.Equal(t, expectedCredentialSubject, vc.CredentialSubject)
-		assert.Equal(t, validChain[0].NotAfter, *vc.ExpirationDate, "expiration date of VC must match signing certificate")
+			assert.Equal(t, expectedCredentialSubject, vc.CredentialSubject)
+			assert.Equal(t, validChain[0].NotAfter, *vc.ExpirationDate, "expiration date of VC must match signing certificate")
+		})
+		t.Run("only include san/otherName", func(t *testing.T) {
+			validChain, err := internal.ParseCertificatesFromPEM([]byte(internal.TestCertificateChain))
+			require.NoError(t, err, "failed to parse chain")
+
+			vc, err := Issue(validChain, validChain[3], validKey, "did:example:123")
+
+			require.NoError(t, err, "failed to issue verifiable credential")
+			require.NotNil(t, vc, "verifiable credential is nil")
+
+			assert.Equal(t, "https://www.w3.org/2018/credentials/v1", vc.Context[0].String())
+			assert.True(t, vc.IsType(ssi.MustParseURI("VerifiableCredential")))
+			assert.True(t, vc.IsType(ssi.MustParseURI("X509Credential")))
+			assert.Equal(t, "did:x509:0:sha256:DwXSf2_jaUod7cezXBGJBM4AaaoA8DI9j7aPMDTI-mQ::san:otherName:2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333", vc.Issuer.String())
+
+			expectedCredentialSubject := []interface{}{map[string]interface{}{
+				"id": "did:example:123",
+				"san": map[string]interface{}{
+					"otherName": "2.16.528.1.1007.99.2110-1-1111111-S-2222222-00.000-333333",
+				},
+			}}
+
+			assert.Equal(t, expectedCredentialSubject, vc.CredentialSubject)
+			assert.Equal(t, validChain[0].NotAfter, *vc.ExpirationDate)
+		})
 	})
 
 	t.Run("ok - correct escaping of special characters", func(t *testing.T) {

--- a/did_x509/did_x509.go
+++ b/did_x509/did_x509.go
@@ -49,11 +49,11 @@ func FormatDid(issuerCert *x509.Certificate, policy ...string) (*did.DID, error)
 // It extracts the Unique Registration Address (URA) from the chain, creates a policy with it, and formats the DID.
 // Returns the generated DID or an error if any step fails.
 func CreateDid(signingCert, caCert *x509.Certificate, includedSubjectTypes []x509_cert.SubjectTypeName, includedSanTypes ...x509_cert.SanTypeName) (*did.DID, error) {
-	otherNames, err := x509_cert.SelectSanTypes(signingCert, includedSanTypes...)
+	alternativeNames, err := x509_cert.SelectSanTypes(signingCert, includedSanTypes...)
 	if err != nil {
 		return nil, err
 	}
-	policies, err := formatPolicies(otherNames)
+	policies, err := formatPolicies(alternativeNames)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type VC struct {
 	CAFingerprintDN   string                      `arg:"" short:"c" name:"ca_fingerprint_dn" help:"The full subject DN (distinguished name) of the CA certificate to be used as ca-fingerprint in the X.509 DID. The certificate must be present in the chain specified by certificate_file."`
 	SubjectDID        string                      `arg:"" name:"subject_did" help:"The subject DID of the Verifiable Credential."`
 	SubjectAttributes []x509_cert.SubjectTypeName `short:"s" name:"subject_attr" help:"List of X.509 subject attributes to include in the Verifiable Credential." default:"O,L"`
-	IncludePermanent  bool                        `short:"p" help:"Include the permanent identifier in the did:x509."`
+	SANAttributes     []string                    `short:"a" help:"List of SAN attributes to include in the Verifiable Credential (options: 'otherName', 'permanentIdentifier.assigner', 'permanentIdentifier.value')." default:"otherName"`
 }
 
 var _ error = InvalidCAFingerprintDNError{}
@@ -124,7 +124,10 @@ func issueVc(vc VC) (string, error) {
 		return "", err
 	}
 
-	credential, err := credential_issuer.Issue(chain, caFingerprintCert, key, vc.SubjectDID, credential_issuer.SubjectAttributes(vc.SubjectAttributes...))
+	credential, err := credential_issuer.Issue(chain, caFingerprintCert, key, vc.SubjectDID,
+		credential_issuer.SubjectAttributes(vc.SubjectAttributes...),
+		credential_issuer.SANAttributes(vc.SANAttributes...),
+	)
 
 	if err != nil {
 		return "", err

--- a/x509_cert/x509_utils.go
+++ b/x509_cert/x509_utils.go
@@ -139,14 +139,14 @@ func FindSanTypes(certificate *x509.Certificate) ([]*PolicyValue, error) {
 	return rv, nil
 }
 
-func SelectSanTypes(certificate *x509.Certificate, subjectAttributes ...SanTypeName) ([]*PolicyValue, error) {
+func SelectSanTypes(certificate *x509.Certificate, sanTypes ...SanTypeName) ([]*PolicyValue, error) {
 	subjectTypes, err := FindSanTypes(certificate)
 	if err != nil {
 		return nil, err
 	}
 	var selectedSubjectTypes []*PolicyValue
 	for _, subjectType := range subjectTypes {
-		if slices.Contains(subjectAttributes, subjectType.Type) {
+		if slices.Contains(sanTypes, subjectType.Type) {
 			selectedSubjectTypes = append(selectedSubjectTypes, subjectType)
 		}
 	}


### PR DESCRIPTION
Changes:
- Fixes permanentIdentifier SAN attributes to be only included in the Verifiable Credential if specified
- Fixes specifying SAN types, they (otherName, permanentIdentifier) can now be explicitly included/excluded. By default, it includes otherName only (current behavior).

Fixes https://github.com/nuts-foundation/go-didx509-toolkit/issues/64

@gerardsn can you test the fix with your certificate?