### PR TITLE
Add HealthcareProviderCredential issuance type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.24.5-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/credential_issuer/healthcare_provider_credential.go
+++ b/credential_issuer/healthcare_provider_credential.go
@@ -54,7 +54,9 @@ func IssueHealthcareProviderCredential(chain []*x509.Certificate, caFingerprintC
 		return nil, fmt.Errorf("certificate subject does not contain an Organization (O) attribute")
 	}
 	template := HealthcareProviderTemplate(*issuer, signingCert.NotAfter, subjectDID, ura, organizationName)
-	return IssueCredential(template, chain, issuer, signingCert, key, jwa.PS256)
+	// RS256: UZI/PKIoverheid certificates are RSA and the AORTA ecosystem expects
+	// RS256 (RSA PKCS#1 v1.5), not PS256 (RSA-PSS).
+	return IssueCredential(template, chain, issuer, signingCert, key, jwa.RS256)
 }
 
 // HealthcareProviderTemplate builds a HealthcareProviderCredential template per the AORTA-on-FHIR spec:

--- a/credential_issuer/healthcare_provider_credential.go
+++ b/credential_issuer/healthcare_provider_credential.go
@@ -1,0 +1,90 @@
+package credential_issuer
+
+import (
+	"crypto"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-did/did"
+	"github.com/nuts-foundation/go-did/vc"
+	"github.com/nuts-foundation/go-didx509-toolkit/x509_cert"
+)
+
+// HealthcareProviderCredentialType holds the name of the HealthcareProviderCredential type.
+var HealthcareProviderCredentialType = ssi.MustParseURI("HealthcareProviderCredential")
+
+// HealthcareProviderCredentialContext is the JSON-LD context URI for the HealthcareProviderCredential,
+// derived from the credential type. The AORTA-on-FHIR spec models this as a deployment-specific
+// <aorta-gbc-base>/gbc/context/v1; the toolkit standardizes on the shared vzvz.nl context.
+var HealthcareProviderCredentialContext = ssi.MustParseURI("https://vzvz.nl/credentials/v1")
+
+// uraNamingSystem is the FHIR NamingSystem URI for the URA identifier.
+const uraNamingSystem = "http://fhir.nl/fhir/NamingSystem/ura"
+
+// IssueHealthcareProviderCredential issues a HealthcareProviderCredential as a JWT VC, signed with the given key
+// and using a did:x509 issuer derived from the chain and caFingerprintCert. Shape per the AORTA-on-FHIR
+// HealthcareProviderCredential specification. The URA and organization name being attested to are parsed from
+// the signing certificate: URA from the SAN otherName UZI value, name from the subject's O (Organization) attribute.
+func IssueHealthcareProviderCredential(chain []*x509.Certificate, caFingerprintCert *x509.Certificate, key crypto.Signer, subjectDID string, optionFns ...Option) (*vc.VerifiableCredential, error) {
+	issuer, err := resolveIssuer(chain, caFingerprintCert, resolveOptions(optionFns...))
+	if err != nil {
+		return nil, err
+	}
+	signingCert := chain[0]
+	ura, err := ExtractURA(signingCert)
+	if err != nil {
+		return nil, err
+	}
+	subjectTypes, err := x509_cert.FindSubjectTypes(signingCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse subject attributes: %w", err)
+	}
+	var organizationName string
+	for _, s := range subjectTypes {
+		if s.Type == x509_cert.SubjectTypeOrganization {
+			organizationName = s.Value
+			break
+		}
+	}
+	if organizationName == "" {
+		return nil, fmt.Errorf("certificate subject does not contain an Organization (O) attribute")
+	}
+	template := HealthcareProviderTemplate(*issuer, signingCert.NotAfter, subjectDID, ura, organizationName)
+	return IssueCredential(template, chain, issuer, signingCert, key, jwa.PS256)
+}
+
+// HealthcareProviderTemplate builds a HealthcareProviderCredential template per the AORTA-on-FHIR spec:
+// credentialSubject has @type HealthcareProvider, a single identifier object (@type Identifier, URA system+value)
+// and the organization name.
+func HealthcareProviderTemplate(issuerDID did.DID, expirationDate time.Time, subjectDID, ura, organizationName string) vc.VerifiableCredential {
+	iat := time.Now()
+	id := did.DIDURL{
+		DID:      issuerDID,
+		Fragment: uuid.NewString(),
+	}.URI()
+	return vc.VerifiableCredential{
+		Issuer: issuerDID.URI(),
+		Context: []ssi.URI{
+			ssi.MustParseURI("https://www.w3.org/2018/credentials/v1"),
+			HealthcareProviderCredentialContext,
+		},
+		Type:           []ssi.URI{ssi.MustParseURI("VerifiableCredential"), HealthcareProviderCredentialType},
+		ID:             &id,
+		IssuanceDate:   iat,
+		ExpirationDate: &expirationDate,
+		CredentialSubject: []map[string]any{{
+			"id":    subjectDID,
+			"@type": "HealthcareProvider",
+			"identifier": map[string]any{
+				"@type":  "Identifier",
+				"system": uraNamingSystem,
+				"value":  ura,
+			},
+			"name": organizationName,
+		}},
+	}
+}

--- a/credential_issuer/healthcare_provider_credential_test.go
+++ b/credential_issuer/healthcare_provider_credential_test.go
@@ -1,0 +1,58 @@
+package credential_issuer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jws"
+	ssi "github.com/nuts-foundation/go-did"
+	"github.com/nuts-foundation/go-didx509-toolkit/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssueHealthcareProviderCredential(t *testing.T) {
+	chain, err := internal.ParseCertificatesFromPEM([]byte(internal.TestCertificateChain))
+	require.NoError(t, err)
+	key, err := internal.ParseRSAPrivateKeyFromPEM([]byte(internal.TestSigningKey))
+	require.NoError(t, err)
+
+	credential, err := IssueHealthcareProviderCredential(chain, chain[3], key,
+		"did:web:ziekenhuis-voorbeeld.nl")
+	require.NoError(t, err)
+	require.NotNil(t, credential)
+
+	assert.True(t, credential.IsType(ssi.MustParseURI("VerifiableCredential")))
+	assert.True(t, credential.IsType(HealthcareProviderCredentialType))
+	require.Len(t, credential.Context, 2)
+	assert.Equal(t, "https://www.w3.org/2018/credentials/v1", credential.Context[0].String())
+	assert.Equal(t, "https://vzvz.nl/credentials/v1", credential.Context[1].String())
+
+	// Shape per the AORTA-on-FHIR HealthcareProviderCredential spec: @type HealthcareProvider,
+	// a single identifier object (@type Identifier, URA system+value) and the organization name.
+	expectedSubject := []map[string]any{{
+		"id":    "did:web:ziekenhuis-voorbeeld.nl",
+		"@type": "HealthcareProvider",
+		"identifier": map[string]any{
+			"@type":  "Identifier",
+			"system": "http://fhir.nl/fhir/NamingSystem/ura",
+			"value":  "2222222",
+		},
+		"name": "Faux Care",
+	}}
+	assert.Equal(t, expectedSubject, credential.CredentialSubject)
+	assert.Equal(t, chain[0].NotAfter, *credential.ExpirationDate)
+
+	t.Run("credentialSubject is serialized as a JSON object, not an array", func(t *testing.T) {
+		parsed, err := jws.Parse([]byte(credential.Raw()))
+		require.NoError(t, err)
+		var payload struct {
+			VC struct {
+				CredentialSubject json.RawMessage `json:"credentialSubject"`
+			} `json:"vc"`
+		}
+		require.NoError(t, json.Unmarshal(parsed.Payload(), &payload))
+		require.NotEmpty(t, payload.VC.CredentialSubject)
+		assert.Equal(t, byte('{'), payload.VC.CredentialSubject[0], "credentialSubject must be a JSON object, got: %s", string(payload.VC.CredentialSubject))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuts-foundation/go-didx509-toolkit
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 const (
 	credentialTypeX509                   = "X509Credential"
 	credentialTypeHealthcareOrganization = "HealthcareOrganizationCredential"
+	credentialTypeHealthcareProvider     = "HealthcareProviderCredential"
 )
 
 type VC struct {
@@ -28,7 +29,7 @@ type VC struct {
 	// CAFingerprintDN specifies the subject DN of the certificate that should be used as did:x509 ca-fingerprint property.
 	CAFingerprintDN   string                      `arg:"" short:"c" name:"ca_fingerprint_dn" help:"The full subject DN (distinguished name) of the CA certificate to be used as ca-fingerprint in the X.509 DID. The certificate must be present in the chain specified by certificate_file."`
 	SubjectDID        string                      `arg:"" name:"subject_did" help:"The subject DID of the Verifiable Credential."`
-	Type              string                      `name:"type" short:"t" help:"Type of Verifiable Credential to issue (options: 'X509Credential', 'HealthcareOrganizationCredential')." default:"X509Credential" enum:"X509Credential,HealthcareOrganizationCredential"`
+	Type              string                      `name:"type" short:"t" help:"Type of Verifiable Credential to issue (options: 'X509Credential', 'HealthcareOrganizationCredential', 'HealthcareProviderCredential')." default:"X509Credential" enum:"X509Credential,HealthcareOrganizationCredential,HealthcareProviderCredential"`
 	SubjectAttributes []x509_cert.SubjectTypeName `short:"s" name:"subject_attr" help:"List of X.509 subject attributes to include in the Verifiable Credential." default:"O,L"`
 	SANAttributes     []string                    `short:"a" help:"List of SAN attributes to include in the Verifiable Credential (options: 'otherName', 'permanentIdentifier.assigner', 'permanentIdentifier.value')." default:"otherName"`
 }
@@ -116,6 +117,15 @@ func issueVc(vc VC) (string, error) {
 		return credential.Raw(), nil
 	case credentialTypeHealthcareOrganization:
 		credential, err := credential_issuer.IssueHealthcareOrganizationCredential(chain, caFingerprintCert, key, vc.SubjectDID,
+			credential_issuer.SubjectAttributes(vc.SubjectAttributes...),
+			credential_issuer.SANAttributes(vc.SANAttributes...),
+		)
+		if err != nil {
+			return "", err
+		}
+		return credential.Raw(), nil
+	case credentialTypeHealthcareProvider:
+		credential, err := credential_issuer.IssueHealthcareProviderCredential(chain, caFingerprintCert, key, vc.SubjectDID,
 			credential_issuer.SubjectAttributes(vc.SubjectAttributes...),
 			credential_issuer.SANAttributes(vc.SANAttributes...),
 		)


### PR DESCRIPTION
Adds a `HealthcareProviderCredential` issuance type alongside the existing `X509Credential` and `HealthcareOrganizationCredential`.

## What
- `vc --type HealthcareProviderCredential <chain.pem> <key.pem> <ca_fingerprint_dn> <subject_did>` self-issues a `HealthcareProviderCredential` via a `did:x509` issuer.
- Shape per the [AORTA-on-FHIR HealthcareProviderCredential spec](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/healthcareprovidercredential):
  - `credentialSubject.@type` = `HealthcareProvider`
  - single-object `identifier` (`@type: Identifier`, `system` = `http://fhir.nl/fhir/NamingSystem/ura`, `value` = URA)
  - `name` = organization
- URA parsed from the signing cert's SAN `otherName` (UZI), name from subject `O` — same extraction as `HealthcareOrganizationCredential`.
- `@context` is derived from the credential type (no flag), mirroring `HealthcareOrganizationCredential`.
- Signed with **RS256** (UZI/PKIoverheid certs are RSA; the AORTA ecosystem expects RS256, not PS256).

## Go upgrade (folded in)
- `go.mod` directive: `go 1.25.0` → `go 1.26.0` (latest stable minor).
- Dockerfile builder image: `golang:1.24.5-alpine` → `golang:1.26.4-alpine` (was pinned older than even the previous directive).

## Why
The AORTA authorization server validates a `HealthcareProviderCredential` (distinct type + subject shape from `HealthcareOrganizationCredential`) and requires a `did:x509` issuer with the URA in the certificate SAN.

## Tests
`credential_issuer/healthcare_provider_credential_test.go` covers the shape and single-object `identifier` serialization. Full suite green.

Assisted by AI