### PR TITLE
Add scheduled govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,23 @@
+name: govulncheck
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
## Why

Dependabot's `gomod` ecosystem updates module dependencies (the `require` block) but never bumps the Go toolchain/language version directive in `go.mod`. That leaves a gap: vulnerabilities in the Go standard library or toolchain — fixable only by upgrading Go — are never surfaced.

## What

Standalone scheduled workflow running `govulncheck ./...`:

- **Weekly** (Monday 06:00 UTC) + manual `workflow_dispatch`.
- Call-graph aware — only reports vulnerabilities the code actually reaches.
- Covers the standard library and toolchain, complementing Dependabot rather than duplicating it.

Follows the existing `go.yml` conventions (`actions/checkout@v4`, `actions/setup-go@v4`, `go-version: 'stable'`).

Assisted by AI