### PR TITLE
Bump Go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # golang alpine
-FROM golang:1.24.5-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuts-foundation/go-didx509-toolkit
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
## What

- `go.mod` directive: `go 1.25.0` → `go 1.26.0` (latest stable minor).
- Dockerfile builder image: `golang:1.24.5-alpine` → `golang:1.26.4-alpine` (was pinned older than even the previous directive).

## Notes

- The `go` directive sets the minimum language version. The security-relevant toolchain (latest patch, currently 1.26.4) is supplied by CI's `go-version: 'stable'` and the pinned Docker builder.
- `go build ./...` and `go test ./...` pass locally.

Assisted by AI