### PR TITLE
Group dependabot updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,11 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Switch dependabot from daily, ungrouped updates to **weekly grouped** PRs.

- `gomod`: weekly, grouped (minor+patch).
- **Major** bumps stay outside the group as individual PRs, so cross-breaking-change updates that need judgment remain individually reviewable.
- Preserves soak time and anti-drift currency.

Assisted by AI